### PR TITLE
enable feature `doc_auto_cfg` for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,13 @@ categories = ["gui"]
 readme = "README.md"
 license = "MIT"
 
-[package.metadata.docs.rs]
-features = ["tokio"]
+[features]
+default = []
 
 [dependencies]
 fltk = "1.4"
 tokio = { version = "1", features = ["rt"], optional = true }
 async-std = { version = "1", optional = true }
-
-[features]
-default = []
-
-[[example]]
-name = "tokio_ex"
-doc-scrape-examples = true
-required-features = [ "tokio" ]
-
-[[example]]
-name = "async_std_ex"
-required-features = [ "async-std" ]
 
 [dev-dependencies]
 # for doctest of feature tokio and example tokio_ex
@@ -39,3 +27,16 @@ reqwest = "0.11"
 # for example async_std_ex
 async-std = { version = "1", features = ["attributes"] }
 surf = "2"
+
+[[example]]
+name = "tokio_ex"
+doc-scrape-examples = true
+required-features = ["tokio"]
+
+[[example]]
+name = "async_std_ex"
+required-features = ["async-std"]
+
+[package.metadata.docs.rs]
+features = ["tokio"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
+
 #![doc = include_str!("../README.md")]
 
 #![cfg_attr(feature = "tokio", doc = concat!(r##"


### PR DESCRIPTION
# Description
enable feature `doc_auto_cfg` for docs.rs

Enhance docs in docs.rs by adding target/feature mark to item.  
Test it local:
```shell
RUSTFLAGS="--cfg=docsrs" RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --open
```
